### PR TITLE
Auto shutdown option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ function logs_callback(buffer) {
 }
 ```
 
+### auto_shutdown
+Type: `boolean`
+Default: false
+
+Will automatically shutdown the mongodb server when the parent process either exits or throws an uncaught exception
+
 ## Logging
 To see logs in stdout, set environment variable DEBUG to `mongodb`
 

--- a/index.js
+++ b/index.js
@@ -68,6 +68,13 @@ function start_server(opts, callback) {
 			}
 			mongodb_logs(data.toString().slice(0, -1));
 		});
+		if (opts.auto_shutdown) {
+			function shutdown() {
+				child.kill('SIGTERM');
+			}
+			process.on('uncaughtException', shutdown);
+			process.on('exit', shutdown);
+		}
 	}
 }
 


### PR DESCRIPTION
Since there appears to be no way to shut down a server that's started, I've added a quick and easy "auto_shutdown" option that will shutdown the server on any uncaught exception or process exits. 

I'm open to alternatives but this seemed the cleanest way to handle what I need out of this library.
