### PR TITLE
Use separate event emitter per server

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var path = require('path');
 var install = require('./install');
 var proc = require('child_process');
 var EventEmitter = require('events').EventEmitter;
-var emitter = new EventEmitter();
 var debug = require('debug')('mongodb-prebuilt');
 var mongodb_logs = require('debug')('mongodb');
 
@@ -17,6 +16,7 @@ module.exports = {
 };
 
 function start_server(opts, callback) {
+	var emitter = new EventEmitter();
 	emitter.once('mongoStarted', callback);
 	if (!opts) {
 		opts = {};


### PR DESCRIPTION
I encountered an issue due to the same event emitter being used for multiple calls to start_server. Slightly tricky to debug and explain, but consistently reproducible:
### Issue report
#### Steps to reproduce
- Call `start_server` with config that will cause startup to fail, passing in a callback `A`
- Server startup fails, so `A` is never called
- Call `start_server` again with correct config, passing in a callback `B`
- Server starts up
#### Expected result

Callback `B` is invoked
#### Actual result

Both callbacks `A` and `B` are invoked
### Suggested fix (this PR)

This is confusing for consumers and not a wildly unreasonable use case (e.g. if an integration test can't predict which configs will work in advance, so needs to try a few options). It's avoided by instantiating a new event emitter for each call to `start_server` and I don't see any downside to this.

Cheers,
Harry
