### PR TITLE
Pass global set proxy settings to mongodb-download

### DIFF
--- a/install.js
+++ b/install.js
@@ -9,18 +9,24 @@
   var Decompress = require('decompress');
   var download = require('mongodb-download');
   var debug = require('debug')('mongodb-prebuilt');
-
+  var HttpsProxyAgent = require('https-proxy-agent');
   var LATEST_STABLE_RELEASE = "3.2.0";
 
   function install(version, callback) {
     if (!version) {
       version = process.env.npm_config_mongo_version || LATEST_STABLE_RELEASE;
     }
-    debug("installing version: %s", version);
-    // downloads if not cached
-    download({
+    var params = {
       version: version
-    }, function(err, archive) {
+    };
+    debug("installing version: %s", version);
+    if(process.env.HTTPS_PROXY) {
+      debug("setting proxy for request");
+      params.http_opts = {};
+      params.http_opts.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+    }
+    // downloads if not cached
+    download(params, function(err, archive) {
       if (err) {
         return callback(err);
       }

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "url": "https://github.com/winfinit/mongodb-prebuilt/issues"
   },
   "dependencies": {
-    "mongodb-download": "^1.2.1",
-    "decompress": "^3.0.0",
     "debug": "^2.2.0",
+    "decompress": "^3.0.0",
+    "https-proxy-agent": "^1.0.0",
+    "mongodb-download": "^1.2.1",
     "yargs": "^3.26.0"
   },
   "homepage": "https://github.com/winfinit/mongodb-prebuilt#readme"


### PR DESCRIPTION
This pull request passes the global set proxy settings to mongodb-download. So as mentioned in this issue (https://github.com/winfinit/mongodb-prebuilt/issues/20) a download through a corporate proxy will be possible.
