### PR TITLE
spawn sync only with --fork

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function start_server(opts, callback) {
     }
 
     if (opts.args.fork === undefined) {
-        opts.args.fork = true;
+        opts.args.fork = false;
     }
 
     if (!opts.args.logpath) {
@@ -68,7 +68,8 @@ function start_server(opts, callback) {
 
     function start() {
         debug("spawn", bpath + "mongod", args.join(' '));
-        var child = spawnSync(bpath + "mongod", args);
+        var spawn = (opts.args.fork)? spawnSync : require('child_process').spawn;
+        var child = spawn(bpath + "mongod", args);
         mongodb_logs(child.stdout.toString());
         mongodb_logs(child.stderr.toString());
 


### PR DESCRIPTION
Mongod doesn't support --fork on Windows. so forcing it to true leads to errors (see mccormicka/Mockgoose#207 ). Without --fork  spawnSync will block the event loop indefinitely.

So, here is a fix for both the issues.
