### PR TITLE
Fix shutdown is not a function message

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,14 @@ module.exports = {
 
 // persist created child pid
 var child_pid = 0;
+var killer;
 
 function shutdown (e) {
     if (child_pid !== 0) {
         debug('killing mongod process: %d', child_pid);
         process.removeListener('exit', shutdown);
         process.kill(child_pid);
+        killer.kill();
     }
 };
 
@@ -89,7 +91,7 @@ function start_server(opts, callback) {
         // if mongod started, spawn killer
         if (child.status === 0) {
             debug('starting mongokiller.js, ppid:%d\tmongod pid:%d', process.pid, child_pid);
-            var killer = proc.spawn("node", [path.join(__dirname, "binjs", "mongokiller.js"), process.pid, child_pid], {
+            killer = proc.spawn("node", [path.join(__dirname, "binjs", "mongokiller.js"), process.pid, child_pid], {
                 stdio: 'ignore',
                 detached: true
             });

--- a/index.js
+++ b/index.js
@@ -23,9 +23,10 @@ module.exports = {
 // persist created child pid
 var child_pid = 0;
 
-var shutdown = function(e) {
+function shutdown (e) {
     if (child_pid !== 0) {
         debug('killing mongod process: %d', child_pid);
+        process.removeListener('exit', shutdown);
         process.kill(child_pid);
     }
 };


### PR DESCRIPTION
`shutdown` variable is used before declared (https://github.com/winfinit/mongodb-prebuilt/blob/master/index.js#L26), leading to a "shutdown is not a function message" error if you try to call the function.  

This fixes the error and it also removes the 'exit' listener on shutdown to avoid side effects 
