### PR TITLE
Always use `callback`; Fix on-the-fly install [BREAKING]

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,6 +165,7 @@ function active_version() {
 }
 
 function install(version, callback) {
+    var _install = require('./install');
     try {
         var bPath = bin_path(version);
         if (dir_exists(bPath)) {
@@ -173,15 +174,10 @@ function install(version, callback) {
             ));
         }
 
-        var spawn_opts = [];
-        if (version) {
-            spawn_opts.push('--version', version);
-        }
-        if (process.env.https_proxy) {
-            spawn_opts.push('--https-proxy', process.env.https_proxy);
-        }
-        var install_out = child_process.spawnFileSync('./install.js', spawn_opts);
-        callback(!!install_out.status);
+        _install({
+            version: version,
+            httpProxy: process.env.https_proxy
+        }, callback);
     }
     catch (err) { callback(err); }
 }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function start_server(opts, callback) {
             debug('MongoDB version ' + opts.version + ' not installed. Installing now...')
             return install(opts.version, function(err) {
                 if (err) {
-                    debug('Failed to debug MongoDB version ' + opts.version + ': ' + err.message);
+                    debug('Failed to download MongoDB version ' + opts.version + ': ' + err.message);
                     callback(err);
                 } else {
                     debug('Successfully installed MongoDB version ' + opts.version);

--- a/index.js
+++ b/index.js
@@ -58,15 +58,15 @@ function start_server(opts, callback) {
 
         var bpath = bin_path(opts.version);
         if (!bpath) {
+            debug('MongoDB version ' + opts.version + ' not installed. Installing now...')
             return install(opts.version, function(err) {
                 if (err) {
+                    debug('Failed to debug MongoDB version ' + opts.version + ': ' + err.message);
                     callback(err);
                 } else {
-                    try {
-                        bpath = bin_path(opts.version);
-                        start(callback);
-                    }
-                    catch (err) { callback(err) }
+                    debug('Successfully installed MongoDB version ' + opts.version);
+                    // Try again, now that MongoDB is installed
+                    start_server(opts, callback);
                 }
             });
         } else {
@@ -115,11 +115,8 @@ function start_server(opts, callback) {
 function dir_exists(dir) {
     try {
         var stats = fs.lstatSync(dir);
-        if (stats.isDirectory()) {
-            return true;
-        }
+        return stats.isDirectory();
     } catch (e) {
-        debug("error from lstat:", e);
         return false;
     }
 }

--- a/install.js
+++ b/install.js
@@ -85,7 +85,7 @@ var argv = require('yargs').argv;
     module.exports = install;
 
     if (!module.parent) {
-        var mongodb_version = process.argv[2] || null;
+        var mongodb_version = process.argv[2] || process.env.npm_config_mongo_version || null;
         install(mongodb_version, function(err) {
             if (err) {
                 console.error('Error during installation:', err);

--- a/install.js
+++ b/install.js
@@ -60,17 +60,20 @@ var argv = require('yargs').argv;
             }
             debug("archive type selected %s", archive_type);
 
+            var destPath = path.join(__dirname, 'dist', version);
             var decomp = new Decompress({
                 mode: '755'
             })
               .src(archive)
-              .dest(path.join(__dirname, 'dist', version))
+              .dest(destPath)
               .use(Decompress[archive_type]({
                   strip: 1
               }));
 
             var out = decomp.run(function(err, files) {
-                debug('inside extract, run complete');
+                if (!err) {
+                    debug('inside extract, run complete. Extracted to ' + destPath);
+                }
                 callback(err);
             });
         }

--- a/install.js
+++ b/install.js
@@ -16,17 +16,17 @@ var argv = require('yargs').argv;
 
     var LATEST_STABLE_RELEASE = "3.2.0";
 
-    function install(version, callback) {
+    function install(opts, callback) {
         try {
-            if (!version) {
-                version = process.env.npm_config_mongo_version || LATEST_STABLE_RELEASE;
-            }
+            opts = opts || {};
+            var version = opts.version || LATEST_STABLE_RELEASE;
+
             debug("installing version: %s", version);
             var download_opts = {
                 version: version
             }
-            if (argv.http_proxy || process.env.npm_config_https_proxy) {
-                var proxy_uri = process.env.npm_config_https_proxy || argv.http_proxy;
+            if (opts.httpsProxy || process.env.npm_config_https_proxy) {
+                var proxy_uri = process.env.npm_config_https_proxy || opts.httpsProxy;
                 debug("using HTTP proxy for download:", proxy_uri);
                 var proxy_agent = new https_proxy_agent(proxy_uri);
                 download_opts.http_opts = {
@@ -70,7 +70,7 @@ var argv = require('yargs').argv;
               }));
 
             var out = decomp.run(function(err, files) {
-                console.log('inside extract, run complete');
+                debug('inside extract, run complete');
                 callback(err);
             });
         }
@@ -85,9 +85,11 @@ var argv = require('yargs').argv;
         var mongodb_version = process.argv[2] || null;
         install(mongodb_version, function(err) {
             if (err) {
-                console.log('Error during installation:', err);
+                console.error('Error during installation:', err);
+                process.exit(1);
             } else {
                 console.log('Done installing MongoDB');
+                process.exit(0);
             }
         });
     }

--- a/install.js
+++ b/install.js
@@ -25,8 +25,8 @@ var argv = require('yargs').argv;
             var download_opts = {
                 version: version
             }
-            if (opts.httpsProxy || process.env.npm_config_https_proxy) {
-                var proxy_uri = process.env.npm_config_https_proxy || opts.httpsProxy;
+            if (opts.httpsProxy) {
+                var proxy_uri = opts.httpsProxy;
                 debug("using HTTP proxy for download:", proxy_uri);
                 var proxy_agent = new https_proxy_agent(proxy_uri);
                 download_opts.http_opts = {
@@ -86,7 +86,10 @@ var argv = require('yargs').argv;
 
     if (!module.parent) {
         var mongodb_version = process.argv[2] || process.env.npm_config_mongo_version || null;
-        install(mongodb_version, function(err) {
+        install({
+            version: mongodb_version,
+            httpsProxy: process.env.npm_config_https_proxy
+        }, function(err) {
             if (err) {
                 console.error('Error during installation:', err);
                 process.exit(1);

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   },
   "dependencies": {
     "mongodb-download": "^1.3.2",
-    "decompress": "^3.0.0",
     "debug": "^2.2.0",
     "yargs": "^3.26.0",
     "https-proxy-agent": "^1.0.0",
-    "spawn-sync": "1.0.15"
+    "spawn-sync": "1.0.15",
+    "fs-extra": "^0.30.0"
   },
   "homepage": "https://github.com/winfinit/mongodb-prebuilt#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aeris-mongodb-prebuilt",
+  "name": "mongodb-prebuilt",
   "version": "6.0.0",
   "description": "Install MongoDB prebuilt binaries via npm",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mongodb-prebuilt",
-  "version": "5.0.6",
+  "name": "aeris-mongodb-prebuilt",
+  "version": "6.0.0",
   "description": "Install MongoDB prebuilt binaries via npm",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes two major fixes:
- `start_server` always resolves/errors using the provided `callback` function (breaking change) (see #12)
- Fix "on-the-fly" MongoDB server installation, when requesting a custom MongoDB version (see #30)

It also improves error handling for a bug in `mongodb-download` (see e1b03861a2cb6b0f17353027fe618bc26fa47d44)
