### PR TITLE
Fix: Ensure that starting server under Windows through Mockgoose does not …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 *.log
 *.swp
+.idea

--- a/install.js
+++ b/install.js
@@ -14,7 +14,7 @@ var argv = require('yargs').argv;
     var https_proxy_agent = require('https-proxy-agent');
 
 
-    var LATEST_STABLE_RELEASE = "3.2.0";
+    var LATEST_STABLE_RELEASE = "3.4.2";
 
     function install(version, callback) {
         if (!version) {


### PR DESCRIPTION
based on: https://github.com/admin-ch/mongodb-prebuilt/commit/cad20d7ba06cce4355edb1faf5b5c3c5b41f1b84

We cannot get child.status when running on Windows system.
Since ChildProcess object does not have status property.
Look ChildProcess((https://nodejs.org/api/child_process.html#child_process_child_process), 
spawn(https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options)
However in this way, we cannot be sure that mongod is correctly called on Windows...
