### PR TITLE
Add stop() and kill() methods to manage mongod

### DIFF
--- a/src/mongod-helper.ts
+++ b/src/mongod-helper.ts
@@ -28,6 +28,14 @@ export class MongodHelper {
     })
   }
 
+  stop(): void {
+    this.mongoBin.childProcess.kill('SIGINT')
+  }
+
+  kill(): void {
+    this.mongoBin.childProcess.kill('SIGTERM')
+  }
+
   closeHandler(code: number): void {
     this.debug(`mongod close: ${code}`);
   }


### PR DESCRIPTION
Mocha 4+ changed behaviour to "no longer force the process to exit once all tests complete"
so async tasks will keep the test run from completing, the prebuilt-mongod daemon is such a task

This adds helper functions to allow a test to finish

`stop()` will send a `SIGINT` to cleanly shutdown
`kill()` will send a `SIGTERM`

Fixes #38