### PR TITLE
Add ability to control mongo download

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ let {MongodHelper} = require('mongodb-prebuilt');
 
 let mongodHelper = new MongodHelper(['--port', "27018"]);
 
+// OPTIONAL: to control what version of mongo you want to download
+
+mongodHelper = new MongodHelper(['--port', "27018"], {
+	version: 'x.x.x'
+});
+
 mongodHelper.run().then((started) => {
 	console.log('mongod is running');
 }, (e) => {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "mongodb-prebuilt",
   "version": "6.3.5",
   "description": "Install MongoDB prebuilt binaries via npm",
-  "main": "built/mongodb-prebuilt-all",   
-  "types": "built/mongodb-prebuilt-all.d.ts", 
+  "main": "built/mongodb-prebuilt-all",
+  "types": "built/mongodb-prebuilt-all.d.ts",
   "scripts": {
-    "cache-clean": "rm -rf dist *.txt"
+    "cache-clean": "rm -rf dist *.txt",
+    "prepare": "npm run clean && npm run tsc",
+    "tsc": "rm -rf built && tsc",
+    "clean": "rm -rf built",
+    "lint-ts": "tslint -c tslint.json './src/**/*.ts' --fix"
   },
   "bin": {
     "bsondump": "built/bin/bsondump.js",
@@ -52,8 +56,10 @@
   },
   "devDependencies": {
     "@types/node": "^6.0.58",
+    "chai": "^3.5.0",
     "mocha": "^3.2.0",
-    "chai": "^3.5.0"  
+    "tsc": "^1.20150623.0",
+    "typescript": "^2.9.2"
   },
   "homepage": "https://github.com/winfinit/mongodb-prebuilt#readme"
 }

--- a/src/mongo-bins.ts
+++ b/src/mongo-bins.ts
@@ -1,8 +1,10 @@
 const Debug: any = require('debug');
-import {resolve as resolvePath} from 'path';
-import {SpawnOptions, ChildProcess, spawn as spawnChild} from 'child_process';
-import {MongoDBPrebuilt} from './mongodb-prebuilt';
-import {MongoSupervise} from './mongodb-supervise';
+import { resolve as resolvePath } from 'path';
+import { SpawnOptions, ChildProcess, spawn as spawnChild } from 'child_process';
+import { IMongoDBDownloadOpts } from './mongod-helper';
+import { MongoDBPrebuilt } from './mongodb-prebuilt';
+import { MongoSupervise } from './mongodb-supervise';
+import { MongoDBDownload } from 'mongodb-download';
 
 export class MongoBins {
   command: string;
@@ -13,15 +15,23 @@ export class MongoBins {
   mongoDBPrebuilt: MongoDBPrebuilt;
 
   constructor(
-    command: string, 
+    command: string,
     public commandArguments: string[] = [],
-    public spawnOptions: SpawnOptions = {}
+    public spawnOptions: SpawnOptions = {},
+
+    downloadOptions?: IMongoDBDownloadOpts
   ) {
+
     this.debug = Debug(`mongodb-prebuilt-MongoBins`);
     this.command = command;
-    this.mongoDBPrebuilt = new MongoDBPrebuilt();
+    if (downloadOptions) {
+      this.mongoDBPrebuilt = new MongoDBPrebuilt(downloadOptions);
+    } else {
+      this.mongoDBPrebuilt = new MongoDBPrebuilt();
+    }
+
   }
-  
+
   run(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       this.runCommand().then(() => {

--- a/src/mongo-bins.ts
+++ b/src/mongo-bins.ts
@@ -43,18 +43,18 @@ export class MongoBins {
           this.debug(`run() Supervise process didn't start: ${e}`);
         });
         resolve(true);
-      }, (e)=> {
+      }, (e) => {
         this.debug(`error executing command ${e}`);
         reject(e);
       });
     });
   }
-  
-  runCommand(): Promise<boolean>  {
+
+  runCommand(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       let getCommandPromise: Promise<string> = this.getCommand();
       let getCommandArgumentsPromise: Promise<string[]> = this.getCommandArguments();
-      
+
       Promise.all([
         getCommandPromise,
         getCommandArgumentsPromise
@@ -70,11 +70,11 @@ export class MongoBins {
 
     });
   }
-  
+
   getCommand(): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       this.mongoDBPrebuilt.getBinPath().then(binPath => {
-        let command: string= resolvePath(binPath, this.command);
+        let command: string = resolvePath(binPath, this.command);
         this.debug(`getCommand(): ${command}`);
         resolve(command);
       });

--- a/src/mongod-helper.ts
+++ b/src/mongod-helper.ts
@@ -47,7 +47,7 @@ export class MongodHelper {
   stderrHandler(message: string | Buffer): void {
     this.debug(`mongod stderr: ${message}`);
   }
-  
+
   stdoutHandler(message: string | Buffer): void {
     this.debug(`mongod stdout: ${message}`);
     let log: string = message.toString();
@@ -57,28 +57,28 @@ export class MongodHelper {
     let mongodPermissionDeniedExpression: RegExp = this.getMongodPermissionDeniedExpression();
     let mongodDataDirNotFounddExpression: RegExp = this.getMongodDataDirNotFounddExpression();
     let mongodShutdownMessageExpression: RegExp = this.getMongodShutdownMessageExpression();
-    
-    if ( mongodStartExpression.test(log) ) {
+
+    if (mongodStartExpression.test(log)) {
       this.resolveLink(true);
     }
 
-    if ( mongodAlreadyRunningExpression.test(log) ) {
+    if (mongodAlreadyRunningExpression.test(log)) {
       return this.rejectLink('already running');
     }
 
-    if ( mongodAlreadyRunningExpression.test(log) ) {
+    if (mongodAlreadyRunningExpression.test(log)) {
       return this.rejectLink('already running');
     }
 
-    if ( mongodPermissionDeniedExpression.test(log) ) {
+    if (mongodPermissionDeniedExpression.test(log)) {
       return this.rejectLink('permission denied');
     }
 
-    if ( mongodDataDirNotFounddExpression.test(log) ) {
+    if (mongodDataDirNotFounddExpression.test(log)) {
       return this.rejectLink('Data directory not found');
     }
 
-    if ( mongodShutdownMessageExpression.test(log) ) {
+    if (mongodShutdownMessageExpression.test(log)) {
       return this.rejectLink('Mongod shutting down');
     }
 

--- a/src/mongod-helper.ts
+++ b/src/mongod-helper.ts
@@ -1,25 +1,37 @@
-import {MongoBins} from './mongo-bins';
+import { MongoBins } from './mongo-bins';
 const Debug: any = require('debug');
 
 const COMMAND: string = "mongod";
 
+export interface IMongoDBDownloadOpts {
+  platform?: string;
+  arch?: string;
+  version?: string;
+  downloadDir?: string;
+  http?: any;
+}
+
 export class MongodHelper {
   mongoBin: MongoBins;
   debug: any;
-  
-  private resolveLink: (response: boolean) => void = () => {};
-  private rejectLink: (response: string) => void = () => {};
-  
-  constructor(commandArguments: string[] = []) {
-    this.mongoBin = new MongoBins(COMMAND, commandArguments);
+
+  private resolveLink: (response: boolean) => void = () => { };
+  private rejectLink: (response: string) => void = () => { };
+
+  constructor(commandArguments: string[] = [], downloadOptions?: IMongoDBDownloadOpts) {
+    if (downloadOptions) {
+      this.mongoBin = new MongoBins(COMMAND, commandArguments, {}, downloadOptions);
+    } else {
+      this.mongoBin = new MongoBins(COMMAND, commandArguments);
+    }
     this.debug = Debug(`mongodb-prebuilt-MongodHelper`);
   }
-  
+
   run(): Promise<boolean> {
     return new Promise<boolean>((resolve, reject) => {
       this.resolveLink = resolve;
       this.rejectLink = reject;
-      
+
       this.mongoBin.run().then(() => {
         this.mongoBin.childProcess.stderr.on('data', (data) => this.stderrHandler(data));
         this.mongoBin.childProcess.stdout.on('data', (data) => this.stdoutHandler(data));

--- a/src/mongodb-prebuilt.ts
+++ b/src/mongodb-prebuilt.ts
@@ -43,7 +43,7 @@ export class MongoDBPrebuilt {
       })
     });
   }
-  
+
   private resolveBinPath(extractLocation: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       let binPath: string = `${extractLocation}/*/bin`;
@@ -52,7 +52,7 @@ export class MongoDBPrebuilt {
           this.debug(`resolveBinPath() error ${err}`);
           reject(err);
         } else {
-          if ( this.hasValidBinPath(files) === true ) {
+          if (this.hasValidBinPath(files) === true) {
             let resolvedBinPath: string = files[0];
             this.debug(`resolveBinPath(): ${resolvedBinPath}`);
             resolve(resolvedBinPath);
@@ -63,18 +63,18 @@ export class MongoDBPrebuilt {
       });
     });
   }
-  
+
   private hasValidBinPath(files: string[]): boolean {
-    if ( files.length === 1 ) {
+    if (files.length === 1) {
       return true;
-    } else if ( files.length > 1 ) {
+    } else if (files.length > 1) {
       this.debug(`getBinPath() directory corrupted, only one installation per hash can exist`);
       return false
     } else {
       this.debug(`getBinPath() doesn't exist, files: ${files}`);
       return false;
-    }    
+    }
   }
-  
+
 }
 


### PR DESCRIPTION
We needed to be able to download a specific version of mongo to run our tests. So we added the ability to pass in options that go to the mongodb-download package. We've tested that this runs cleanly in the default mode as well as with the options.

We also added some scripts for linting and building in package.json. We left in the fix option on the linting which has added a lot of spacing and formatting changes. Apologies for that. 

Fixes #50 
Fixes #42 