### PR TITLE
Passing download parameters to bin commands through ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Complete list of programs:
 
 Works on Mac, Windows, Linux and Solaris OSes that MongoDB supports.
 
+## CLI usage
+The latest version of MongoDB is used by default for your OS and `~/.mongodb-prebuilt` for downloading MongoDB binary.
+You can set desired version, download folder, architecture and platform through environment variables:
+```
+MONGODB_VERSION
+MONGODB_DOWNLOADDIR
+MONGODB_ARCH
+MONGODB_PLATFORM
+```
+For example:
+```
+export MONGODB_DOWNLOADDIR='./' MONGODB_VERSION=3.4.10
+mongod --port 27018 --dbpath ./mongodb --logpath /dev/stdout
+```
 ## Programmatic usage
 
 ```javascript

--- a/src/bin/bsondump.ts
+++ b/src/bin/bsondump.ts
@@ -1,11 +1,4 @@
 #!/usr/bin/env node
+import { runCommand } from './runCommandHelper';
 
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "bsondump";
-
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('bsondump');

--- a/src/bin/mongo.ts
+++ b/src/bin/mongo.ts
@@ -1,12 +1,4 @@
 #!/usr/bin/env node
+import { runCommand } from './runCommandHelper';
 
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongo";
-
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-	console.log('command is running');
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongo');

--- a/src/bin/mongod.ts
+++ b/src/bin/mongod.ts
@@ -1,12 +1,4 @@
 #!/usr/bin/env node
+import { runCommand } from './runCommandHelper';
 
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongod";
-
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
-
+runCommand('mongod');

--- a/src/bin/mongodump.ts
+++ b/src/bin/mongodump.ts
@@ -1,11 +1,4 @@
 #!/usr/bin/env node
+import { runCommand } from './runCommandHelper';
 
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongodump";
-
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongodump');

--- a/src/bin/mongoexport.ts
+++ b/src/bin/mongoexport.ts
@@ -1,11 +1,4 @@
 #!/usr/bin/env node
+import { runCommand } from './runCommandHelper';
 
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongoexport";
-
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongoexport');

--- a/src/bin/mongofiles.ts
+++ b/src/bin/mongofiles.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongofiles";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongofiles');

--- a/src/bin/mongoimport.ts
+++ b/src/bin/mongoimport.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongoimport";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongoimport');

--- a/src/bin/mongooplog.ts
+++ b/src/bin/mongooplog.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongooplog";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongooplog');

--- a/src/bin/mongoperf.ts
+++ b/src/bin/mongoperf.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongoperf";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongoperf');

--- a/src/bin/mongorestore.ts
+++ b/src/bin/mongorestore.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongorestore";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongorestore');

--- a/src/bin/mongos.ts
+++ b/src/bin/mongos.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongos";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongos');

--- a/src/bin/mongosniff.ts
+++ b/src/bin/mongosniff.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongosniff";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongosniff');

--- a/src/bin/mongostat.ts
+++ b/src/bin/mongostat.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongostat";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongostat');

--- a/src/bin/mongotop.ts
+++ b/src/bin/mongotop.ts
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-import {MongoBins} from '../mongo-bins';
-const COMMAND: string = "mongotop";
+import { runCommand } from './runCommandHelper';
 
-let mongoBin: MongoBins = new MongoBins(COMMAND, process.argv.slice(2), {stdio: 'inherit'});
-mongoBin.run().then(() => {
-	//console.log(`${COMMAND} is now running`);
-}, (e) => {
-	console.error(`unable to launch ${COMMAND}`, e);
-});
+runCommand('mongotop');

--- a/src/bin/runCommandHelper.ts
+++ b/src/bin/runCommandHelper.ts
@@ -1,0 +1,28 @@
+import { MongoBins } from '../mongo-bins';
+import { IMongoDBDownloadOptions } from 'mongodb-download';
+
+export function runCommand(command: string) {
+  const downloadOpts = getDownloadOpts();
+  const mongoBin: MongoBins = new MongoBins(command, process.argv.slice(2), { stdio: 'inherit' }, downloadOpts);
+
+  mongoBin.run()
+    // .then(() => console.log(`${command} is now running`))
+    .catch((error) => console.error(`unable to launch ${command}`, error));
+}
+
+function getDownloadOpts() : Partial<IMongoDBDownloadOptions> {
+  const opts: Partial<IMongoDBDownloadOptions> = {};
+  setIfExists(opts, 'version');
+  setIfExists(opts, 'downloadDir');
+  setIfExists(opts, 'arch');
+  setIfExists(opts, 'platform');
+
+  return Object.keys(opts).length > 0 ? opts : undefined;
+}
+
+function setIfExists(obj: Partial<IMongoDBDownloadOptions>, property: keyof IMongoDBDownloadOptions): void {
+  const value = process.env['MONGODB_' + property.toUpperCase()];
+  if (value) {
+    obj[property] = value;
+  }
+}


### PR DESCRIPTION
Main goal of the pr is to set MongoDB version and download folder instead of latest version of MongoDB and home directory to download to use through bin commands.

Environment variables to set mongodb download parameters:
`MONGODB_VERSION`
`MONGODB_DOWNLOADDIR`
`MONGODB_ARCH`
`MONGODB_PLATFORM`

Example
`export mongodb_downloadDir='./' mongodb_version=3.4.10 && mongod --port 27018 --dbpath ./.mongodb/data --logpath /dev/stdout`
