### PR TITLE
fix: changing the start regex to support the old and new logs

### DIFF
--- a/src/mongod-helper.ts
+++ b/src/mongod-helper.ts
@@ -86,7 +86,7 @@ export class MongodHelper {
   }
 
   getMongodStartedExpression(): RegExp {
-    return /waiting for connections on port/i;
+    return /waiting for connections/i;
   }
 
   getMongodAlreadyRunningExpression(): RegExp {


### PR DESCRIPTION
Mongodb has changed the structure of their logs in newer versions. The old structure was:

```
2020-03-10T13:18:09.076-0600 I NETWORK  [initandlisten] waiting for connections on port 27017
```
to
```
{"t":{"$date":"2020-03-10T19:15:53.408+0000"},"s":"I", "c":"NETWORK", "id":23016,"ctx":"listener","msg":"Waiting for connections","attr":{"port":27017,"ssl":"off"}}
```

This change is backwards compatible with older versions and windows as it's just a shorter version of the regular expression.